### PR TITLE
[mlops] small typo fix: credentials

### DIFF
--- a/ml-ops-poc/02-Developers.ipynb
+++ b/ml-ops-poc/02-Developers.ipynb
@@ -65,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* vim ~/.aws/credetial"
+    "* vim ~/.aws/credentials"
    ]
   },
   {


### PR DESCRIPTION
```
../.aws/credetial -> ../.aws/credentials
```